### PR TITLE
Lazily reporting traffic

### DIFF
--- a/measured.go
+++ b/measured.go
@@ -273,12 +273,16 @@ func (mc *Conn) Close() (err error) {
 
 func (mc *Conn) submitTrafficIfNecessary() {
 	now := time.Now()
+	needToSubmit := false
 	mc.submitMutex.Lock()
 	if now.Sub(mc.lastSubmitted) > mc.interval {
-		mc.submitTraffic()
+		needToSubmit = true
 		mc.lastSubmitted = now
 	}
 	mc.submitMutex.Unlock()
+	if needToSubmit {
+		mc.submitTraffic()
+	}
 }
 
 func (mc *Conn) submitTraffic() {

--- a/measured_test.go
+++ b/measured_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"runtime"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 func TestReportStats(t *testing.T) {
 	md, nr := startWithMockReporter()
 	defer md.Stop()
-	var bytesIn, bytesOut uint64
 	var RemoteAddr string
 
 	// start server with byte counting
@@ -29,11 +27,8 @@ func TestReportStats(t *testing.T) {
 	s := http.Server{
 		Handler: http.NotFoundHandler(),
 		ConnState: func(c net.Conn, s http.ConnState) {
-			if s == http.StateIdle {
+			if s == http.StateClosed {
 				RemoteAddr = c.RemoteAddr().String()
-				mc := c.(*Conn)
-				atomic.StoreUint64(&bytesIn, mc.BytesIn)
-				atomic.StoreUint64(&bytesOut, mc.BytesOut)
 			}
 		},
 	}
@@ -50,15 +45,10 @@ func TestReportStats(t *testing.T) {
 	req, _ := http.NewRequest("GET", "http://"+l.Addr().String(), nil)
 	resp, _ := c.Do(req)
 	assert.Equal(t, 404, resp.StatusCode)
-	assert.True(t, atomic.LoadUint64(&bytesIn) > 0, "should count bytesIn")
-	assert.True(t, atomic.LoadUint64(&bytesOut) > 0, "should count bytesOut")
 
-	// make sure client will report another once
-	time.Sleep(200 * time.Millisecond)
 	// Close without reading from body, to force server to close connection
 	_ = resp.Body.Close()
 	time.Sleep(100 * time.Millisecond)
-	// verify both client and server stats
 	nr.Lock()
 	defer nr.Unlock()
 	t.Logf("Traffic entries: %+v", nr.traffic)
@@ -67,21 +57,17 @@ func TestReportStats(t *testing.T) {
 		st := nr.traffic[RemoteAddr]
 
 		if assert.NotNil(t, ct) {
-			assert.Equal(t, uint64(0), ct.MinOut, "client stats should only report increased byte count")
-			assert.Equal(t, uint64(0), ct.MinIn, "client stats should only report increased byte count")
-			assert.Equal(t, uint64(0), ct.LastOut, "client stats should only report increased byte count")
-			assert.Equal(t, uint64(0), ct.LastIn, "client stats should only report increased byte count")
-			assert.Equal(t, uint64(0), ct.TotalOut, "client stats should only report increased byte count")
-			assert.Equal(t, uint64(0), ct.TotalIn, "client stats should only report increased byte count")
+			assert.Equal(t, 0, int(ct.MinOut), "client stats should only report increased byte count")
+			assert.Equal(t, 0, int(ct.MinIn), "client stats should only report increased byte count")
+			assert.Equal(t, 96, int(ct.MaxOut), "client stats should only report increased byte count")
+			assert.Equal(t, 176, int(ct.MaxIn), "client stats should only report increased byte count")
+			assert.Equal(t, 96, int(ct.TotalOut), "client stats should only report increased byte count")
+			assert.Equal(t, 176, int(ct.TotalIn), "client stats should only report increased byte count")
 		}
 
 		if assert.NotNil(t, st) {
-			assert.Equal(t, bytesIn, st.TotalIn, "should report server stats with bytes in")
-			assert.Equal(t, bytesOut, st.TotalOut, "should report server stats with bytes out")
-			assert.Equal(t, bytesIn, st.LastIn, "should report server stats with bytes in")
-			assert.Equal(t, bytesOut, st.LastOut, "should report server stats with bytes out")
-			assert.Equal(t, bytesIn, st.MinIn, "should report server stats with bytes in")
-			assert.Equal(t, bytesOut, st.MinOut, "should report server stats with bytes out")
+			assert.Equal(t, ct.TotalOut, st.TotalIn, "should report server stats with bytes in")
+			assert.Equal(t, ct.TotalIn, st.TotalOut, "should report server stats with bytes out")
 		}
 	}
 }


### PR DESCRIPTION
Instead of spawning a goroutine for each connection, I just report on read/write if more than interval time has elapsed.  This has the downside that on idle connections, there may be up to interval worth of activity that hasn't been reported yet, but this will get reported when the connection is closed.  The upside is that it performs a lot better.