### PR TITLE
Slowed down mockconn so that measured test records some traffic

### DIFF
--- a/measured.go
+++ b/measured.go
@@ -13,7 +13,6 @@ import (
 const (
 	ioTimeout       = "i/o timeout"
 	ioTimeoutLength = 11
-	rateInterval    = 1 * time.Second
 )
 
 // Stats provides statistics about total transfer and rates, all in bytes.
@@ -66,7 +65,7 @@ func Wrap(wrapped net.Conn, rateInterval time.Duration, onFinish func(Conn)) Con
 		onFinish:         onFinish,
 		trackingFinished: make(chan bool),
 	}
-	go c.track()
+	go c.track(rateInterval)
 	return c
 }
 
@@ -88,7 +87,7 @@ func (c *conn) Wrapped() net.Conn {
 	return c.Conn
 }
 
-func (c *conn) track() {
+func (c *conn) track(rateInterval time.Duration) {
 	for {
 		c.sent.calc()
 		c.recv.calc()


### PR DESCRIPTION
Closes getlantern/lantern-internal#684 

The test was failing because the Write and Read on MockConn on Windows are faster than the resolution of the timer used by mtime, so it looks as if no time has passed between starting and advancing the Rater.

I introduce an artificial delay so that the Write and Read take longer than the resolution of the timer and now test passes.

In the real world, Write and Read are syscalls that should be slow enough to rise above the resolution, plus we'll almost always get multiple calls to each, so this is really just a test issue.

cc: @uaalto This bug unfortunately does not explain why we see so little Xfer data in Borda right now. I'll look into that separately.